### PR TITLE
ヘッダ要素を解釈するマークダウンパーサの作成

### DIFF
--- a/app/markdown_parser.py
+++ b/app/markdown_parser.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import Union
 import dataclasses
+import re
 
 
 @dataclasses.dataclass
@@ -48,6 +49,17 @@ class MarkdownParser:
 
 class Parser:
     """ マークダウンで書かれた行の解釈を責務に持つ """
+
+    def is_target(self, markdown_text: str) -> bool:
+        """
+        マークダウンの行が現在参照しているパーサの処理対象であるか判定
+        たとえば、`# Heading`の場合、HeadingParserのみTrueを返し、それ以外はFalseを返す
+
+        :param markdown_text: 判定対象行
+        :return: パース対象 ->True パース対象でない -> False
+        """
+        raise NotImplementedError()
+
     def parse(self, markdown_text: str) -> Block:
         """
         マークダウンの行を解釈し、種類に応じてBlock/Inlineを生成
@@ -60,10 +72,25 @@ class Parser:
 
 class HeadingParser(Parser):
     """ ヘッダの解釈を責務に持つ"""
+    PATTERN = '^(#+) (.*)'
 
     def __init__(self):
         pass
 
+    def is_target(self, markdown_text: str) -> bool:
+        return re.match(self.PATTERN, markdown_text) is not None
+
+    # TODO 将来的にはinline_parserをリストで受け取り、Inline要素も解釈できるようにしたい
+    # TODO スタイルはオブジェクトへと変更 オブジェクトのプロパティでヘッダの種類を識別
     def parse(self, markdown_text: str) -> Block:
-        # TODO 変換処理実装
-        pass
+        """
+        ヘッダ行を解釈
+
+        :param markdown_text: 処理対象行
+        :return: ヘッダを表すBlock要素
+        """
+
+        match: re.Match = re.match(self.PATTERN, markdown_text)
+        heading_style, text = (match.group(1), match.group(2))
+
+        return Block('Heading', [text])

--- a/tests/markdown_parser_test.py
+++ b/tests/markdown_parser_test.py
@@ -1,4 +1,6 @@
-from app.markdown_parser import MarkdownParser, ParseResult, Block
+import pytest
+
+from app.markdown_parser import MarkdownParser, ParseResult, Block, HeadingParser
 from tests.util import equal_for_parse_result
 
 
@@ -12,3 +14,27 @@ class TestMarkdownParser:
         actual = sut.parse(['HelloWorld'])
         # THEN
         assert equal_for_parse_result(actual, expected)
+
+    class TestHeading:
+
+        @pytest.mark.parametrize(('text', 'expected'), [
+            ('# this is heading', True),
+            ('this is not heading', False),
+            ('###Without space', False),
+            ('＃FullWidth character', False)
+        ], ids=['heading', 'not heading', 'no space', 'FullWidth'])
+        def test_target(self, text: str, expected: bool):
+            # GIVEN
+            sut = HeadingParser()
+            # WHEN
+            actual = sut.is_target(text)
+            # THEN
+            assert actual == expected
+
+        def test_parse(self):
+            # GIVEN
+            sut = HeadingParser()
+            # WHEN
+            actual = sut.parse('# This is Heading')
+            assert actual.style == 'Heading'
+            assert actual.children[0] == 'This is Heading'


### PR DESCRIPTION
## 概要

`## Heading2`のような、マークダウンで書かれたヘッダ記法をヘッダ要素として解釈する処理をつくりたい。
具体的には、MarkdownParserにて、ヘッダ記法を解釈すると、ヘッダ要素と対応するBlock要素を生成できるようにしたい。

### やること

* MarkdownParserの子処理として、HeadingParserを作成
* HeadingParserにて、ヘッダ記法(1~6個の半角`#`で始まり、半角スペースを挟んで文字列が続く行)を満たすか判定
* 満たす場合は、`Heading1`, `Heading4`のように、ヘッダの種類を続けて判定
* 最終的な戻り値として、ヘッダを表すスタイル文字列・Block要素を返却

* 上記処理のテストコードを作成