### PR TITLE
記法を表すスタイル要素を文字列からオブジェクトへ変更

### DIFF
--- a/app/element/block.py
+++ b/app/element/block.py
@@ -1,0 +1,25 @@
+import dataclasses
+from typing import Union
+
+from app.element.style import Style, Plain, Heading
+from app.element.inline import Inline
+
+
+@dataclasses.dataclass
+class Block:
+    """ 行要素を保持 """
+    style: Style
+    children: list[Union['Block', Inline, str]]
+
+
+@dataclasses.dataclass
+class PlainBlock(Block):
+    """ どの記法にも属さない要素 """
+    style: Plain
+    children: str
+
+
+@dataclasses.dataclass
+class HeadingBlock(Block):
+    """ ヘッダ要素 """
+    style: Heading

--- a/app/element/inline.py
+++ b/app/element/inline.py
@@ -1,0 +1,9 @@
+import dataclasses
+from app.element.style import Style
+
+
+@dataclasses.dataclass
+class Inline:
+    """ aタグのようなインラインスタイルを保持 """
+    style: Style
+    text: str

--- a/app/element/style.py
+++ b/app/element/style.py
@@ -1,0 +1,16 @@
+import dataclasses
+
+
+class Style:
+    """ マークダウン・HTMLの記法の種類を表現 """
+
+
+class Plain(Style):
+    """ 修飾のないことを表現 """
+
+
+@dataclasses.dataclass
+class Heading(Style):
+    """ ヘッダ要素を表現 """
+    # h1, h3のようなヘッダの大きさを表現
+    size: int

--- a/app/html_builder.py
+++ b/app/html_builder.py
@@ -1,11 +1,12 @@
-from app.markdown_parser import ParseResult, Inline, Block
+from app.markdown_parser import ParseResult
+from app.element.block import Block, PlainBlock, HeadingBlock
 
 
 class HtmlBuilder:
     """ HTML文字列の生成を責務に持つ """
 
     def __init__(self):
-        pass
+        self.builders = [HeadingBuilder()]
 
     def build(self, html_input: ParseResult) -> str:
         """
@@ -15,20 +16,43 @@ class HtmlBuilder:
         :return: HTML文字列
         """
 
-        html = ''
+        html = []
 
         for block in html_input.content:
-            if isinstance(block, str):
-                html = html + block
-                continue
 
-            if isinstance(block, Block):
+            for builder in self.builders:
 
-                # TODO ネストしたブロックも扱えるようにしたい
+                line: str = (
+                    (isinstance(block, HeadingBlock) and builder.build(block)) or
+                    (isinstance(block, PlainBlock) and block.children)
+                )
+                html.append(line)
 
-                for child in block.children:
+        return ''.join(html)
 
-                    if isinstance(child, str):
-                        html = html + child
 
-        return html
+class Builder:
+    """ 各タグと対応するHTML要素の組み立てを責務に持つ """
+
+    def build(self, block: Block) -> str:
+        raise NotImplementedError
+
+
+class HeadingBuilder(Builder):
+    """ hタグ(ヘッダ)の組み立てを責務に持つ """
+
+    def build(self, block: HeadingBlock) -> str:
+        """
+        ヘッダのHTML文字列を組み立て
+
+        :param block: 組み立て元Block要素
+        :return: HTMLのヘッダタグを含む文字列
+        """
+
+        text = ''
+        for child in block.children:
+            if isinstance(child, str):
+                text = child
+
+        heading_expression = f'h{block.style.size}'
+        return f'<{heading_expression}>{text}</{heading_expression}>'

--- a/tests/converter_test.py
+++ b/tests/converter_test.py
@@ -1,5 +1,7 @@
 from app.converter import Converter
-from app.markdown_parser import Block, ParseResult
+from app.markdown_parser import ParseResult
+from app.element.style import Plain
+from app.element.block import PlainBlock
 
 from tests.util import equal_for_parse_result
 
@@ -9,9 +11,9 @@ class TestConverter:
     def test_convert_plain(self):
         # GIVEN
         sut = Converter()
-        expected = ParseResult([Block('', ['HelloWorld'])])
+        expected = ParseResult([PlainBlock(Plain(), 'HelloWorld')])
 
         # WHEN
-        actual = sut.convert(ParseResult([Block('', ['HelloWorld'])]))
+        actual = sut.convert(ParseResult([PlainBlock(Plain(), 'HelloWorld')]))
         # THEN
         assert equal_for_parse_result(actual, expected)

--- a/tests/html_builder_test.py
+++ b/tests/html_builder_test.py
@@ -1,5 +1,9 @@
-from app.html_builder import HtmlBuilder
-from app.markdown_parser import ParseResult, Inline, Block
+import pytest
+
+from app.html_builder import HtmlBuilder, HeadingBuilder
+from app.markdown_parser import ParseResult
+from app.element.style import Plain, Heading
+from app.element.block import PlainBlock, HeadingBlock
 
 
 class TestHtmlBuilder:
@@ -9,10 +13,26 @@ class TestHtmlBuilder:
 
         # GIVEN
         expected = 'Hello World'
-        input = ParseResult([Block('', ['Hello World'])])
+        html_input = ParseResult([PlainBlock(Plain(), 'Hello World')])
         sut = HtmlBuilder()
 
         # WHEN
-        actual = sut.build(input)
+        actual = sut.build(html_input)
         # THEN
         assert actual == expected
+
+    class TestHeading:
+
+        @pytest.mark.parametrize(('block', 'expected'), [
+            (HeadingBlock(Heading(size=1), ['this is 1st heading']), '<h1>this is 1st heading</h1>'),
+            (HeadingBlock(Heading(size=4), ['this is 4th heading']), '<h4>this is 4th heading</h4>'),
+
+        ], ids=['1st heading', '4th heading'])
+        def test_build(self, block: HeadingBlock, expected: str):
+
+            # GIVEN
+            sut = HeadingBuilder()
+            # WHEN
+            actual = sut.build(block)
+            # THEN
+            assert actual == expected

--- a/tests/markdown_parser_test.py
+++ b/tests/markdown_parser_test.py
@@ -1,6 +1,8 @@
 import pytest
 
 from app.markdown_parser import MarkdownParser, ParseResult, Block, HeadingParser
+from app.element.block import PlainBlock
+from app.element.style import Plain, Heading
 from tests.util import equal_for_parse_result
 
 
@@ -9,7 +11,7 @@ class TestMarkdownParser:
     def test_plain(self):
         # GIVEN
         sut = MarkdownParser()
-        expected = ParseResult([Block('', ['HelloWorld'])])
+        expected = ParseResult([PlainBlock(Plain(), 'HelloWorld')])
         # WHEN
         actual = sut.parse(['HelloWorld'])
         # THEN
@@ -31,10 +33,14 @@ class TestMarkdownParser:
             # THEN
             assert actual == expected
 
-        def test_parse(self):
+        @pytest.mark.parametrize(('heading_text', 'heading_size', 'text'), [
+            ('# this is heading', 1, 'this is heading'),
+            ('###  3rd heading', 3, ' 3rd heading'),
+        ], ids=['1st heading', '3rd heading'])
+        def test_parse(self, heading_text: str, heading_size: int, text: str):
             # GIVEN
             sut = HeadingParser()
             # WHEN
-            actual = sut.parse('# This is Heading')
-            assert actual.style == 'Heading'
-            assert actual.children[0] == 'This is Heading'
+            actual = sut.parse(heading_text)
+            assert isinstance(actual.style, Heading) and actual.style.size == heading_size
+            assert actual.children[0] == text

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,4 +1,6 @@
-from app.markdown_parser import Inline, Block, ParseResult
+from app.markdown_parser import ParseResult
+from app.element.block import Block
+from app.element.inline import Inline
 
 
 def assert_that_text_file_content_is_same(expected_path: str, actual_path: str):
@@ -22,7 +24,11 @@ def equal_for_inline(former: Inline, latter: Inline) -> bool:
     :param latter: 比較先
     :return: 等しい -> True 等しくない -> False
     """
-    return (former.text == latter.text) and former.style == latter.style
+    print('Inline comparison')
+    equality = (former.text == latter.text) and former.style == latter.style
+    print(f'Inline equality: {equality}')
+
+    return equality
 
 
 def equal_for_block(former: Block, latter: Block) -> bool:
@@ -34,26 +40,35 @@ def equal_for_block(former: Block, latter: Block) -> bool:
     :return: 等しい -> True 等しくない -> False
     """
 
+    print('Equality For Block')
     # 要素数
     if len(former.children) != len(latter.children):
+        print(f'Children count is not same. former:{len(former.children)}, latter: {len(latter.children)}')
         return False
+    print('Block children count is same')
 
     equality = True
     for former_child, latter_child in zip(former.children, latter.children):
 
         # テキスト
         if isinstance(former_child, str) and isinstance(latter_child, str):
+            print('Child text comparison')
             equality = equality and (former_child == latter_child)
+            print(f'Child text equality: {equality}')
             continue
 
         # Inline
         if isinstance(former_child, Inline) and isinstance(latter_child, Inline):
+            print('Child inline comparison')
             equality = equality and equal_for_inline(former_child, latter_child)
+            print(f'Child inline equality: {equality}')
             continue
 
         # Block
         if isinstance(former_child, Block) and isinstance(latter_child, Block):
+            print('Child block comparison')
             equality = equality and equal_for_block(former_child, latter_child)
+            print(f'Child block equality: {equality}')
             continue
 
         return False
@@ -70,14 +85,16 @@ def equal_for_parse_result(former: ParseResult, latter: ParseResult) -> bool:
     :return: 等しい -> True 等しくない -> False
     """
 
+    print('Compare ParserResult')
     # 要素数
     if len(former.content) != len(latter.content):
         return False
+    print('Length is same')
 
     equality = True
     for former_block, latter_block in zip(former.content, latter.content):
-
+        print('Block comparison')
         equality = equality and equal_for_block(former_block, latter_block)
+        print(f'Block equality: {equality}')
 
     return equality
-


### PR DESCRIPTION
## 概要

マークダウン・HTMLそれぞれで対応する記法(ex: ヘッダ, リスト, リンクなど)の種類は、文字列で表現しようと
思っていた。

しかし、マークダウンの変換結果をHTMLで読み取り、記法の種類を判別したいとき、文字列では対応関係が読みづらい
問題があった。
全体の記法を管理する定数クラス・辞書など、読みやすさや補完のことを考えると色々実現する方法が浮かんだ。

ここで、記法によってヘッダの種類など、単なる種別を表す情報以外のものも持ち得ること・インスタンス比較であれば
補完が有効なことから、記法ごとにクラスを用意する手法を採用。
クラスであれば、ヘッダの種類やリストの深さを持たせるなど、細かな処理を挟みたいときにも対応できるはず。

---

以上の背景から、クラスでスタイルを表現する実装を組んでみたい。

### やりたいこと

* スタイルクラスをつくる
* ヘッダのスタイルを表すクラスをつくる イニシャライザでヘッダのサイズを受け取り、`h1`, `h3`のような種類を識別
* スタイルクラスを介してヘッダをマークダウンからHTMLへ渡す処理を実装

* スタイルを介した変換処理・ヘッダ作成処理をテスト