### PR TITLE
リンク要素を解釈するInline要素の作成

### DIFF
--- a/app/element/block.py
+++ b/app/element/block.py
@@ -9,14 +9,13 @@ from app.element.inline import Inline
 class Block:
     """ 行要素を保持 """
     style: Style
-    children: list[Union['Block', Inline, str]]
+    children: list[Union[Inline, 'Block']]
 
 
 @dataclasses.dataclass
 class PlainBlock(Block):
     """ どの記法にも属さない要素 """
     style: Plain
-    children: str
 
 
 @dataclasses.dataclass

--- a/app/element/block.py
+++ b/app/element/block.py
@@ -4,12 +4,14 @@ from typing import Union
 from app.element.style import Style, Plain, Heading
 from app.element.inline import Inline
 
+Children = list[Union[Inline, 'Block']]
+
 
 @dataclasses.dataclass
 class Block:
     """ 行要素を保持 """
     style: Style
-    children: list[Union[Inline, 'Block']]
+    children: Children
 
 
 @dataclasses.dataclass

--- a/app/element/inline.py
+++ b/app/element/inline.py
@@ -1,5 +1,5 @@
 import dataclasses
-from app.element.style import Style
+from app.element.style import Style, Plain, Link
 
 
 @dataclasses.dataclass
@@ -7,3 +7,15 @@ class Inline:
     """ aタグのようなインラインスタイルを保持 """
     style: Style
     text: str
+
+
+@dataclasses.dataclass
+class PlainInline(Inline):
+    """ どの記法にも属さないInline要素 """
+    style: Plain
+
+
+@dataclasses.dataclass
+class LinkInline(Inline):
+    """ aタグと対応するリンク要素を保持 """
+    style: Link

--- a/app/element/style.py
+++ b/app/element/style.py
@@ -14,3 +14,9 @@ class Heading(Style):
     """ ヘッダ要素を表現 """
     # h1, h3のようなヘッダの大きさを表現
     size: int
+
+
+@dataclasses.dataclass
+class Link(Style):
+    """ リンク要素を表現 """
+    href: str

--- a/app/html_builder.py
+++ b/app/html_builder.py
@@ -24,11 +24,14 @@ class HtmlBuilder:
 
                 line: str = (
                     (isinstance(block, HeadingBlock) and builder.build(block)) or
-                    (isinstance(block, PlainBlock) and block.children)
+                    (isinstance(block, PlainBlock) and self._get_plain_text(block))
                 )
                 html.append(line)
 
         return ''.join(html)
+
+    def _get_plain_text(self, block: PlainBlock) -> str:
+        return block.children[0].text
 
 
 class Builder:
@@ -54,5 +57,6 @@ class HeadingBuilder(Builder):
             if isinstance(child, str):
                 text = child
 
+        # <h1>text</h1>のような文字列を生成
         heading_expression = f'h{block.style.size}'
         return f'<{heading_expression}>{text}</{heading_expression}>'

--- a/tests/html_builder_test.py
+++ b/tests/html_builder_test.py
@@ -3,6 +3,7 @@ import pytest
 from app.html_builder import HtmlBuilder, HeadingBuilder
 from app.markdown_parser import ParseResult
 from app.element.style import Plain, Heading
+from app.element.inline import PlainInline
 from app.element.block import PlainBlock, HeadingBlock
 
 
@@ -13,7 +14,7 @@ class TestHtmlBuilder:
 
         # GIVEN
         expected = 'Hello World'
-        html_input = ParseResult([PlainBlock(Plain(), 'Hello World')])
+        html_input = ParseResult([PlainBlock(Plain(), [PlainInline(Plain(), 'Hello World')])])
         sut = HtmlBuilder()
 
         # WHEN
@@ -24,8 +25,8 @@ class TestHtmlBuilder:
     class TestHeading:
 
         @pytest.mark.parametrize(('block', 'expected'), [
-            (HeadingBlock(Heading(size=1), ['this is 1st heading']), '<h1>this is 1st heading</h1>'),
-            (HeadingBlock(Heading(size=4), ['this is 4th heading']), '<h4>this is 4th heading</h4>'),
+            (HeadingBlock(Heading(size=1), [PlainInline(Plain(), 'this is 1st heading')]), '<h1>this is 1st heading</h1>'),
+            (HeadingBlock(Heading(size=4), [PlainInline(Plain(), 'this is 4th heading')]), '<h4>this is 4th heading</h4>'),
 
         ], ids=['1st heading', '4th heading'])
         def test_build(self, block: HeadingBlock, expected: str):


### PR DESCRIPTION
## 概要

ヘッダ記法に対応することで、Block要素の土台は出来上がった。
続いて、Inline要素も土台をつくっておきたい。手頃でかつ、よく使うリンク記法を対象にしてみる。

### やること

* Inline要素を解釈するパーサを作成
* リンクを含む行を解釈するパーサを作成
* ヘッダにリンクを含む行も解釈できるよう、Blockのパーサを手直し

* リンク・ヘッダのテストコードを作成