### PR TITLE
Inline要素の残実装をパース・ビルド

### DIFF
--- a/app/element/inline.py
+++ b/app/element/inline.py
@@ -1,5 +1,5 @@
 import dataclasses
-from app.element.style import Style, Plain, Link
+from app.element.style import Style, Plain, Link, Code
 
 
 @dataclasses.dataclass
@@ -19,3 +19,10 @@ class PlainInline(Inline):
 class LinkInline(Inline):
     """ aタグと対応するリンク要素を保持 """
     style: Link
+
+
+@dataclasses.dataclass
+class CodeInline(Inline):
+    """ codeタグと対応するコード要素を保持 """
+    style: Code
+

--- a/app/element/inline.py
+++ b/app/element/inline.py
@@ -1,5 +1,5 @@
 import dataclasses
-from app.element.style import Style, Plain, Link, Code
+from app.element.style import Style, Plain, Link, Code, Image
 
 
 @dataclasses.dataclass
@@ -26,3 +26,7 @@ class CodeInline(Inline):
     """ codeタグと対応するコード要素を保持 """
     style: Code
 
+
+class ImageInline(Inline):
+    """ imgタグと対応する画像要素を保持 """
+    style: Image

--- a/app/element/style.py
+++ b/app/element/style.py
@@ -20,3 +20,8 @@ class Heading(Style):
 class Link(Style):
     """ リンク要素を表現 """
     href: str
+
+
+@dataclasses.dataclass
+class Code(Style):
+    """ コード要素を表現 """

--- a/app/element/style.py
+++ b/app/element/style.py
@@ -25,3 +25,10 @@ class Link(Style):
 @dataclasses.dataclass
 class Code(Style):
     """ コード要素を表現 """
+
+
+@dataclasses.dataclass
+class Image(Style):
+    """ 画像要素を表現 """
+    src: str
+    alt: str

--- a/app/html/inline_builder.py
+++ b/app/html/inline_builder.py
@@ -1,11 +1,11 @@
-from app.element.inline import Inline, LinkInline
+from app.element.inline import Inline, LinkInline, CodeInline
 
 
 class InlineBuilder:
     """ Inline要素と対応するHTML文字列を組み立てることを責務に持つ """
 
     def __init__(self):
-        self._builders: list[IBuilder] = [LinkBuilder()]
+        self._builders: list[IBuilder] = [LinkBuilder(), CodeBuilder()]
 
     def build(self, inline: Inline) -> str:
         """
@@ -73,3 +73,27 @@ class LinkBuilder(IBuilder):
         )
 
         return anchor_tag
+
+
+class CodeBuilder(IBuilder):
+    """ codeタグで表現されるコード要素を生成することを責務に持つ """
+
+    TEXT_EXPRESSION = '{text}'
+    TEMPLATE = f'<code>{TEXT_EXPRESSION}</code>'
+
+    def is_target(self, inline: Inline) -> bool:
+        return isinstance(inline, CodeInline)
+
+    def build(self, inline: CodeInline) -> str:
+        """
+        codeタグ文字列を組み立て
+
+        :param inline: 処理対象Inline要素
+        :return: codeタグ文字列
+        """
+
+        code_tag = self.TEMPLATE.replace(
+            self.TEXT_EXPRESSION, inline.text
+        )
+
+        return code_tag

--- a/app/html/inline_builder.py
+++ b/app/html/inline_builder.py
@@ -1,11 +1,11 @@
-from app.element.inline import Inline, LinkInline, CodeInline
+from app.element.inline import Inline, LinkInline, CodeInline, ImageInline
 
 
 class InlineBuilder:
     """ Inline要素と対応するHTML文字列を組み立てることを責務に持つ """
 
     def __init__(self):
-        self._builders: list[IBuilder] = [LinkBuilder(), CodeBuilder()]
+        self._builders: list[IBuilder] = [LinkBuilder(), CodeBuilder(), ImageBuilder()]
 
     def build(self, inline: Inline) -> str:
         """
@@ -97,3 +97,31 @@ class CodeBuilder(IBuilder):
         )
 
         return code_tag
+
+
+class ImageBuilder(IBuilder):
+    """ imgタグで表現される画像要素を生成することを責務に持つ """
+
+    SRC_EXPRESSION = '{src}'
+    ALT_EXPRESSION = '{alt}'
+
+    TEMPLATE = f'<img src="{SRC_EXPRESSION}" alt="{ALT_EXPRESSION}">'
+
+    def is_target(self, inline: Inline) -> bool:
+        return isinstance(inline, ImageInline)
+
+    def build(self, inline: ImageInline) -> str:
+        """
+        imgタグ文字列を組み立て
+
+        :param inline: 処理対象Inline要素
+        :return: imgタグ文字列
+        """
+
+        img_tag = self.TEMPLATE.replace(
+            self.SRC_EXPRESSION, inline.style.src
+        ).replace(
+            self.ALT_EXPRESSION, inline.style.alt
+        )
+
+        return img_tag

--- a/app/markdown/inline_parser.py
+++ b/app/markdown/inline_parser.py
@@ -1,6 +1,6 @@
 from app.regex import regex
-from app.element.inline import Inline, PlainInline, LinkInline, CodeInline
-from app.element.style import Plain, Link, Code
+from app.element.inline import Inline, PlainInline, LinkInline, CodeInline, ImageInline
+from app.element.style import Plain, Link, Code, Image
 
 
 class InlineParser:
@@ -8,7 +8,7 @@ class InlineParser:
 
     def __init__(self):
         # 各変換処理を表現する要素を初期化
-        self.parsers: list[IParser] = [LinkParser(), CodeParser()]
+        self.parsers: list[IParser] = [LinkParser(), CodeParser(), ImageParser()]
 
     def parse(self, text: str) -> list[Inline]:
         """
@@ -70,8 +70,9 @@ class IParser:
 class LinkParser(IParser):
     """ リンク要素の解釈を責務に持つ """
 
+    # imgタグの記法はリンク要素と共通しているため、除外するためのパターンを設定
     # ex) マークダウンの[Wikipedia](https://en.wikipedia.org/wiki/Markdown)へのリンクです
-    PATTERN = r'(.*)\[(.*)\]\((.*)\)(.*)'
+    PATTERN = r'(.*)(?<!!)\[(.*)\]\((.*)\)(.*)'
 
     def is_target(self, markdown_text: str) -> bool:
         return regex.contain(self.PATTERN, markdown_text)
@@ -110,3 +111,26 @@ class CodeParser(IParser):
         head_text, code_text, tail_text = regex.extract_from_group(self.PATTERN, markdown_text, [1, 2, 3])
 
         return head_text, CodeInline(Code(), code_text), tail_text
+
+
+class ImageParser(IParser):
+    """ 画像要素の解釈を責務に持つ """
+
+    # ex) this ![amazing image](url) is awesome.
+    PATTERN = r'(.*)!\[(.*)\]\((.*)\)(.*)'
+
+    def is_target(self, markdown_text: str) -> bool:
+        return regex.contain(self.PATTERN, markdown_text)
+
+    def parse(self, markdown_text: str) -> tuple[str, Inline, str]:
+        """
+        画像を表すInline要素を生成
+
+        :param markdown_text: 処理対象文字列
+        :return: 画像を表すInline要素
+        """
+
+        head_text, alt, src, tail_text = regex.extract_from_group(self.PATTERN, markdown_text, [1, 2, 3, 4])
+
+        # imgタグは子要素のテキストを持たない
+        return head_text, ImageInline(Image(src=src, alt=alt), ''), tail_text

--- a/app/markdown/inline_parser.py
+++ b/app/markdown/inline_parser.py
@@ -1,6 +1,6 @@
 from app.regex import regex
-from app.element.inline import Inline, PlainInline, LinkInline
-from app.element.style import Plain, Link
+from app.element.inline import Inline, PlainInline, LinkInline, CodeInline
+from app.element.style import Plain, Link, Code
 
 
 class InlineParser:
@@ -8,7 +8,7 @@ class InlineParser:
 
     def __init__(self):
         # 各変換処理を表現する要素を初期化
-        self.parsers: list[IParser] = [LinkParser()]
+        self.parsers: list[IParser] = [LinkParser(), CodeParser()]
 
     def parse(self, text: str) -> list[Inline]:
         """
@@ -88,3 +88,25 @@ class LinkParser(IParser):
         head_text, link_text, href, tail_text = regex.extract_from_group(self.PATTERN, markdown_text, [1, 2, 3, 4])
 
         return head_text, LinkInline(Link(href=href), link_text), tail_text
+
+
+class CodeParser(IParser):
+    """ コード要素の解釈を責務に持つ """
+
+    # ex) Pythonでは、コメントを`#`から始まる行で表現します
+    PATTERN = r'(.*)`(.*)`(.*)'
+
+    def is_target(self, markdown_text: str) -> bool:
+        return regex.contain(self.PATTERN, markdown_text)
+
+    def parse(self, markdown_text: str) -> tuple[str, Inline, str]:
+        """
+        コードを表すInline要素を生成
+
+        :param markdown_text: 処理対象文字列
+        :return: コードを表すInline要素
+        """
+
+        head_text, code_text, tail_text = regex.extract_from_group(self.PATTERN, markdown_text, [1, 2, 3])
+
+        return head_text, CodeInline(Code(), code_text), tail_text

--- a/tests/html/inline_builder_test.py
+++ b/tests/html/inline_builder_test.py
@@ -1,7 +1,7 @@
 import pytest
 
-from app.element.inline import Inline, LinkInline, CodeInline
-from app.html.inline_builder import InlineBuilder, LinkBuilder, CodeBuilder
+from app.element.inline import Inline, LinkInline, CodeInline, ImageInline
+from app.html.inline_builder import InlineBuilder, LinkBuilder, CodeBuilder, ImageBuilder
 
 from tests.util_factory import create_inline
 
@@ -92,6 +92,43 @@ class TestCodeBuilder:
     def test_build(self, inline: CodeInline, expected: str):
         # GIVEN
         sut = CodeBuilder()
+        # WHEN
+        actual = sut.build(inline)
+        # THEN
+        assert actual == expected
+
+
+class TestImageBuilder:
+    """ ImageInline要素からimgタグと対応するHTML文字列が得られるか検証 """
+
+    # 対象判定
+    @pytest.mark.parametrize(('inline', 'expected'), [
+        (create_inline('image', '', src='image.png', alt='image'), True),
+        (create_inline('code', 'code text'), False)
+    ], ids=['target', 'not target'])
+    def test_target(self, inline: Inline, expected: bool):
+        # GIVEN
+        sut = ImageBuilder()
+        # WHEN
+        actual = sut.is_target(inline)
+        # THEN
+        assert actual == expected
+
+    # HTML組み立て
+    @pytest.mark.parametrize(('inline', 'expected'), [
+        (
+            create_inline('image', '', src='images/dog.png', alt='わんこ'),
+            '<img src="images/dog.png" alt="わんこ">'
+        ),
+        (
+            create_inline('image', '', src='http://localhost/image.png', alt='画像'),
+            '<img src="http://localhost/image.png" alt="画像">'
+        )
+
+    ], ids=['path_expression', 'url_expression'])
+    def test_build(self, inline: ImageInline, expected: str):
+        # GIVEN
+        sut = ImageBuilder()
         # WHEN
         actual = sut.build(inline)
         # THEN

--- a/tests/html/inline_builder_test.py
+++ b/tests/html/inline_builder_test.py
@@ -1,7 +1,7 @@
 import pytest
 
-from app.element.inline import Inline, LinkInline
-from app.html.inline_builder import InlineBuilder, LinkBuilder
+from app.element.inline import Inline, LinkInline, CodeInline
+from app.html.inline_builder import InlineBuilder, LinkBuilder, CodeBuilder
 
 from tests.util_factory import create_inline
 
@@ -20,7 +20,14 @@ class TestInlineBuilder:
             ),
             '<a href="https://docs.python.org/3/">参考リンク</a>'
         ),
-    ], ids=['plain', 'link'])
+        (
+            create_inline(
+                'code',
+                'DependencyInjection',
+            ),
+            '<code>DependencyInjection</code>'
+        ),
+    ], ids=['plain', 'link', 'code'])
     def test_build(self, inline: Inline, expected: str):
         # GIVEN
         sut = InlineBuilder()
@@ -55,6 +62,36 @@ class TestLinkBuilder:
     def test_build(self, inline: LinkInline, expected: str):
         # GIVEN
         sut = LinkBuilder()
+        # WHEN
+        actual = sut.build(inline)
+        # THEN
+        assert actual == expected
+
+
+class TestCodeBuilder:
+    """ CodeInline要素からcodeタグと対応するHTML文字列が得られるか検証 """
+
+    # 対象判定
+    @pytest.mark.parametrize(('inline', 'expected'), [
+        (create_inline('code', 'マークダウンの`#`はヘッダを表します'), True),
+        (create_inline('link', 'this is a link', href='url'), False),
+    ], ids=['target', 'not target'])
+    def test_target(self, inline: Inline, expected: bool):
+        # GIVEN
+        sut = CodeBuilder()
+        # WHEN
+        actual = sut.is_target(inline)
+        # THEN
+        assert actual == expected
+
+    # HTML組み立て
+    @pytest.mark.parametrize(('inline', 'expected'), [
+        (create_inline('code', 'plain text'), '<code>plain text</code>'),
+        (create_inline('code', 'codeタグ'), '<code>codeタグ</code>'),
+    ], ids=['plain', 'full width'])
+    def test_build(self, inline: CodeInline, expected: str):
+        # GIVEN
+        sut = CodeBuilder()
         # WHEN
         actual = sut.build(inline)
         # THEN

--- a/tests/markdown/inline_parser_test.py
+++ b/tests/markdown/inline_parser_test.py
@@ -1,7 +1,7 @@
 import pytest
 
-from app.markdown.inline_parser import InlineParser, LinkParser, CodeParser
-from app.element.inline import Inline, LinkInline, CodeInline
+from app.markdown.inline_parser import InlineParser, LinkParser, CodeParser, ImageParser
+from app.element.inline import Inline, LinkInline, CodeInline, ImageInline
 from app.element.style import Link
 from tests.util_equality import equal_for_inline_parse_result, equal_for_inline
 from tests.util_factory import create_inline
@@ -13,12 +13,12 @@ class TestInlineParser:
     # Inline要素生成
     @pytest.mark.parametrize(('text', 'expected'), [
         (
-            'plain text',
-            [create_inline('', 'plain text')]
+                'plain text',
+                [create_inline('', 'plain text')]
         ),
         (
-            'this is [google link](https://www.google.com/)',
-            [create_inline('', 'this is '), create_inline('link', 'google link', href='https://www.google.com/')]
+                'this is [google link](https://www.google.com/)',
+                [create_inline('', 'this is '), create_inline('link', 'google link', href='https://www.google.com/')]
         )
     ], ids=['plain', 'link'])
     def test_parse(self, text: str, expected: list[Inline]):
@@ -36,8 +36,9 @@ class TestLink:
     @pytest.mark.parametrize(('text', 'expected'), [
         ('this is [link](url)', True),
         ('this is not link', False),
-        ('[only link](http://www)', True)
-    ], ids=['link text', 'not link', 'only link'])
+        ('[only link](http://www)', True),
+        ('![image](http://www)', False)
+    ], ids=['link text', 'not link', 'only link', 'image'])
     def test_target(self, text: str, expected: bool):
         sut = LinkParser()
         # WHEN
@@ -49,8 +50,12 @@ class TestLink:
     @pytest.mark.parametrize(('link_text', 'expected'), [
         ('normal[link](url)text', ('normal', LinkInline(Link('url'), 'link'), 'text')),
         ('[link](http)', ('', create_inline('link', 'link', href='http'), '')),
-        ('# heading [head link](https) text', ('# heading ', create_inline('link', 'head link', href='https'), ' text')),
-    ], ids=['normal link', 'only link', 'link with heading'])
+        (
+                '# heading [head link](https) text',
+                ('# heading ', create_inline('link', 'head link', href='https'), ' text')
+        ),
+        ('not ! image [link](url)text', ('not ! image ', LinkInline(Link('url'), 'link'), 'text')),
+    ], ids=['normal link', 'only link', 'link with heading', 'not image'])
     def test_parse(self, link_text: str, expected: tuple[str, LinkInline, str]):
         sut = LinkParser()
         # WHEN
@@ -84,6 +89,58 @@ class TestCode:
     def test_parse(self, text: str, expected: tuple[str, CodeInline, str]):
         # GIVEN
         sut = CodeParser()
+        # WHEN
+        actual = sut.parse(text)
+        # THEN
+        assert equal_for_inline_parse_result(actual, expected)
+
+
+class TestImage:
+    """ ![]()で表現される画像要素を検証 """
+
+    # 対象判定
+    @pytest.mark.parametrize(('text', 'expected'), [
+        ('![画像](img.png)', True),
+        ('[これはリンクです](https://www.google.com', False)
+    ], ids=['target', 'not target'])
+    def test_target(self, text: str, expected: bool):
+        # GIVEN
+        sut = ImageParser()
+        # WHEN
+        actual = sut.is_target(text)
+        # THEN
+        assert actual == expected
+
+    # 記法を解釈
+    @pytest.mark.parametrize(('text', 'expected'), [
+        (
+                '![awesome image](/image.png) is here.',
+                (
+                        '',
+                        create_inline('image', '', src='/image.png', alt='awesome image'),
+                        ' is here.',
+                )
+        ),
+        (
+                'このアイコン![アイコン](/image/icon.png)は良いですね。',
+                (
+                        'このアイコン',
+                        create_inline('image', '', src='/image/icon.png', alt='アイコン'),
+                        'は良いですね。'
+                )
+        ),
+        (
+                '最新の画像![画像](/画像.png)',
+                (
+                        '最新の画像',
+                        create_inline('image', '', src='/画像.png', alt='画像'),
+                        '',
+                )
+        ),
+    ], ids=['head', 'both', 'tail'])
+    def test_parse(self, text: str, expected: tuple[str, ImageInline, str]):
+        # GIVEN
+        sut = ImageParser()
         # WHEN
         actual = sut.parse(text)
         # THEN

--- a/tests/markdown/markdown_parser_test.py
+++ b/tests/markdown/markdown_parser_test.py
@@ -24,7 +24,23 @@ class TestMarkdownParser:
                     '', [create_inline('', '記号'), create_inline('code', '!'), create_inline('', 'は否定を表現します。')])]
                 )
         ),
-    ], ids=['plain', 'heading', 'code'])
+        (
+                ['![image](https://avatars.githubusercontent.com/u/43694794?v=4)'],
+                ParseResult([
+                    create_block(
+                        '',
+                        [
+                            create_inline(
+                                'image',
+                                '',
+                                src='https://avatars.githubusercontent.com/u/43694794?v=4',
+                                alt='image'
+                            ),
+                        ]
+                    )]
+                )
+        ),
+    ], ids=['plain', 'heading', 'code', 'image'])
     def test_parse(self, lines: list[str], expected: ParseResult):
         # GIVEN
         sut = MarkdownParser()

--- a/tests/markdown/markdown_parser_test.py
+++ b/tests/markdown/markdown_parser_test.py
@@ -17,8 +17,14 @@ class TestMarkdownParser:
         (
                 ['## awesome heading'],
                 ParseResult([create_block('heading', [create_inline('', 'awesome heading')], size=2)])
-        )
-    ], ids=['plain', 'heading'])
+        ),
+        (
+                ['記号`!`は否定を表現します。'],
+                ParseResult([create_block(
+                    '', [create_inline('', '記号'), create_inline('code', '!'), create_inline('', 'は否定を表現します。')])]
+                )
+        ),
+    ], ids=['plain', 'heading', 'code'])
     def test_parse(self, lines: list[str], expected: ParseResult):
         # GIVEN
         sut = MarkdownParser()

--- a/tests/util_equality.py
+++ b/tests/util_equality.py
@@ -1,7 +1,7 @@
 from app.markdown.parser import ParseResult
 from app.element.block import Block, Children
 from app.element.inline import Inline
-from app.element.style import Style, Plain, Heading, Link, Code
+from app.element.style import Style, Plain, Heading, Link, Code, Image
 
 
 def assert_that_text_file_content_is_same(expected_path: str, actual_path: str):
@@ -168,15 +168,28 @@ def _equal_for_style(former: Style, latter: Style) -> bool:
     if isinstance(former, Plain):
         return True
 
+    # Block
+    # hタグ
     if isinstance(former, Heading) and isinstance(latter, Heading):
         print(f'Heading comparison former: {former.size}, latter: {latter.size}')
         return former.size == latter.size
 
+    # Inline
+    # aタグ
     if isinstance(former, Link) and isinstance(latter, Link):
         print(f'Link comparison former: {former.href}, latter: {latter.href}')
         return former.href == latter.href
 
+    # codeタグ
     if isinstance(former, Code) and isinstance(latter, Code):
         return True
+
+    # imgタグ
+    if isinstance(former, Image) and isinstance(latter, Image):
+        print('Image comparison')
+        print(f'former.src: {former.src}, latter.src: {latter.src}')
+        print(f'former.alt: {former.alt}, latter.alt: {latter.alt}')
+
+        return former.src == latter.src and former.alt == latter.alt
 
     return True

--- a/tests/util_equality.py
+++ b/tests/util_equality.py
@@ -1,7 +1,7 @@
 from app.markdown.parser import ParseResult
 from app.element.block import Block, Children
 from app.element.inline import Inline
-from app.element.style import Style, Plain, Heading, Link
+from app.element.style import Style, Plain, Heading, Link, Code
 
 
 def assert_that_text_file_content_is_same(expected_path: str, actual_path: str):
@@ -175,5 +175,8 @@ def _equal_for_style(former: Style, latter: Style) -> bool:
     if isinstance(former, Link) and isinstance(latter, Link):
         print(f'Link comparison former: {former.href}, latter: {latter.href}')
         return former.href == latter.href
+
+    if isinstance(former, Code) and isinstance(latter, Code):
+        return True
 
     return True

--- a/tests/util_factory.py
+++ b/tests/util_factory.py
@@ -1,6 +1,6 @@
 from app.element.block import Block, PlainBlock, HeadingBlock, Children
-from app.element.inline import Inline, PlainInline, LinkInline
-from app.element.style import Plain, Heading, Link
+from app.element.inline import Inline, PlainInline, LinkInline, CodeInline
+from app.element.style import Plain, Heading, Link, Code
 
 
 def create_block(block_type: str, children: Children, **kwargs) -> Block:
@@ -35,4 +35,10 @@ def create_inline(inline_type: str, text: str, **kwargs) -> Inline:
     if inline_type == 'link':
         return LinkInline(Link(href=kwargs['href']), text)
 
-    return PlainInline(Plain(), text)
+    if inline_type == 'code':
+        return CodeInline(Code(), text)
+
+    if inline_type == '':
+        return PlainInline(Plain(), text)
+
+    raise Exception('invalid inline type')

--- a/tests/util_factory.py
+++ b/tests/util_factory.py
@@ -1,6 +1,6 @@
 from app.element.block import Block, PlainBlock, HeadingBlock, Children
-from app.element.inline import Inline, PlainInline, LinkInline, CodeInline
-from app.element.style import Plain, Heading, Link, Code
+from app.element.inline import Inline, PlainInline, LinkInline, CodeInline, ImageInline
+from app.element.style import Plain, Heading, Link, Code, Image
 
 
 def create_block(block_type: str, children: Children, **kwargs) -> Block:
@@ -32,11 +32,17 @@ def create_inline(inline_type: str, text: str, **kwargs) -> Inline:
     :return: 生成されたInline要素
     """
 
+    # aタグ
     if inline_type == 'link':
         return LinkInline(Link(href=kwargs['href']), text)
 
+    # codeタグ
     if inline_type == 'code':
         return CodeInline(Code(), text)
+
+    # imgタグ
+    if inline_type == 'image':
+        return ImageInline(Image(src=kwargs['src'], alt=kwargs['alt']), '')
 
     if inline_type == '':
         return PlainInline(Plain(), text)


### PR DESCRIPTION
# 概要

HTMLビルダーを整備することで、一連の流れを通せるようになった。
中間のConverterが絡むのはBlock要素のみであり、Inline要素はシンプルに完結しそう。

よって、残りのInline要素の実装をまとめて済ませてしまいたい。

## Task

* バッククォートで表現される要素のパース
* 画像のパース
* バッククォートで表現される要素からcodeタグの組み立て
* 画像の記法からimgタグの組み立て

* テストコード