### PR TITLE
[#66] コードブロック以下ではHTML要素の文字をエスケープする処理を追加

### DIFF
--- a/a_pompom_markdown_parser/html/block_builder.py
+++ b/a_pompom_markdown_parser/html/block_builder.py
@@ -322,10 +322,28 @@ class CodeBlockBuilder(IBuilder):
         code_block = self.TEMPLATE.replace(
             self.LANGUAGE_EXPRESSION, language_class_name
         ).replace(
-            self.TEXT_EXPRESSION, child_text
+            self.TEXT_EXPRESSION, self._escape_html(child_text)
         )
 
         return code_block
+
+    def _escape_html(self, text: str) -> str:
+        """
+        HTML文字列をエスケープ
+        :param text: 対象テキスト
+        :return: HTML文字列がエスケープされたテキスト
+        """
+        return text.replace(
+            '&', "&amp;"
+        ).replace(
+            '<', "&lt;"
+        ).replace(
+            '>', "&gt;"
+        ).replace(
+            '"', "&quot;"
+        ).replace(
+            "'", "&#039;"
+        )
 
 
 class HorizontalRuleBuilder(IBuilder):

--- a/tests/html/block_builder_test.py
+++ b/tests/html/block_builder_test.py
@@ -351,7 +351,7 @@ class TestCodeBlockBuilder:
                 (
                     f'<pre>{LINE_BREAK}'
                     f'{INDENT}<code class="language-java hljs">'
-                    f'List<String> list;'
+                    f'List&lt;String&gt; list;'
                     f'{INDENT}</code>{LINE_BREAK}'
                     f'</pre>'
                 )

--- a/tests/html/builder_test.py
+++ b/tests/html/builder_test.py
@@ -233,7 +233,7 @@ class TestHtmlBuilder:
                 (f'<pre>{LINE_BREAK}'
                  f'{INDENT}<code class="language-javascript hljs">'
                  f'someFunction(){LINE_BREAK}'
-                 f'> コードは終わっているはず。{LINE_BREAK}'
+                 f'&gt; コードは終わっているはず。{LINE_BREAK}'
                  f'{INDENT}</code>{LINE_BREAK}'
                  f'</pre>{LINE_BREAK}')
             ),

--- a/tests/template/html/block.html
+++ b/tests/template/html/block.html
@@ -48,7 +48,7 @@
 </p>
 <pre>
     <code class="language-python hljs"># comment
-text = 'Hello Block'
+text = &#039;Hello Block&#039;
     </code>
 </pre>
 <hr class="border-b-2 border-indigo-400 mt-6 mb-6">

--- a/tests/template/html/sample_article.html
+++ b/tests/template/html/sample_article.html
@@ -127,7 +127,7 @@
 </p>
 <pre>
     <code class="language-python hljs"># コメントしておきます。
-print('Hello Article!!')
+print(&#039;Hello Article!!&#039;)
     </code>
 </pre>
 <p class="mt-2 mb-2">


### PR DESCRIPTION
コードブロックでHTML文字列が書かれているとレンダリングされ、画面では見えなくなる
これではHTMLタグ文字列を記事などに記述できず不便なので、コードブロック以下ではエスケープする処理を加えた